### PR TITLE
Lager >= 2.0 support and tweaks for the new Loggly HTTP endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+ebin/*
+*.beam
+deps/*
+deps.plt
+.eunit
+.idea
+*.iml
+*.dump
+log
+doc
+dump.rdb
+.rebar
+_rel
+relx

--- a/README.md
+++ b/README.md
@@ -6,16 +6,20 @@ This is a Loggly backend for lager which lets you send lager logs to your Loggly
 ##Configuration
 Configure a Lager handler like the following:
 
-	{lager_loggly_backend, [Identity, Level, MaxRetries, RetryInterval, LogglyUrl]}
-	
-* Identity - The string that all messages get tagged with in Loggly
+	{lager_loggly_backend, [Level, MaxRetries, RetryInterval, LogglyUrl]}
+
 * Level - The lager level at which the  backend accepts messages (eg. using ‘info’ would send all messages at info level or above into syslog)
 * MaxRetries - The maximum number of retries the backend will do before giving up on Loggly
 * RetryInterval - The interval at which each retry is performed. i.e. Retries 5 and Interval 3 means that it will try a maximum of 5 times with 3 seconds apart
-* LogglyUrl - This is your unique Loggly URL for a given Input
+* LogglyUrl - This is your unique Loggly URL for a given Input, including your application specific identity tag
 
 
 An example might look something like this:
 
-	{lager_loggly_backend, [<<"my_id">>, info, 5, 3, "https://logs.loggly.com/inputs/1c6b53a4-972b-4c69-83ea-037de24c9bb2"]}
-Refer to Lager’s documentation for futher information on configuring handlers.
+	{lager_loggly_backend, [info, 5, 3, "https://logs-01.loggly.com/inputs/1c6b53a4-972b-4c69-83ea-037de24c9bb2/tag/my_id/"]}
+
+Refer to Lager’s documentation for further information on configuring handlers.
+
+##Upgrade notes
+
+Since the identity tag should be appended directly to the `LogglyUrl` while accessing the current Loggly API, the previous configuration option `Identity` was removed.

--- a/rebar.config
+++ b/rebar.config
@@ -5,6 +5,6 @@
 }.
 {cover_enabled, true}.
 {deps, [
-        {jsx, "1.4.*", {git, "git://github.com/talentdeficit/jsx.git", {tag, "v1.4.2"}}}
-       ]
-}.
+     {lager, "2.*", {git, "https://github.com/basho/lager.git", {tag, "2.1.1"}}}
+    ,{jsx,   "2.*", {git, "https://github.com/talentdeficit/jsx.git", {tag, "v2.6.2"}}}
+]}.

--- a/rebar.config
+++ b/rebar.config
@@ -1,10 +1,10 @@
 {erl_opts, [
-            warnings_as_errors
+             warnings_as_errors
             ,warn_export_all
            ]
 }.
 {cover_enabled, true}.
 {deps, [
-        {jsx, "1.3.*", {git, "git://github.com/talentdeficit/jsx.git", {tag, "v1.3.3"}}}
+        {jsx, "1.4.*", {git, "git://github.com/talentdeficit/jsx.git", {tag, "v1.4.2"}}}
        ]
 }.

--- a/rebar.config
+++ b/rebar.config
@@ -5,6 +5,6 @@
 }.
 {cover_enabled, true}.
 {deps, [
-     {lager, "2.*", {git, "https://github.com/basho/lager.git", {tag, "2.1.1"}}}
-    ,{jsx,   "2.*", {git, "https://github.com/talentdeficit/jsx.git", {tag, "v2.6.2"}}}
+     {lager, ".*", {git, "https://github.com/basho/lager.git", {tag, "3.0.1"}}}
+    ,{jsx,   "2.*", {git, "https://github.com/talentdeficit/jsx.git", {tag, "v2.7.1"}}}
 ]}.

--- a/src/lager_loggly.app.src
+++ b/src/lager_loggly.app.src
@@ -27,7 +27,7 @@
 {application, lager_loggly,
  [
   {description, "Loggly backend for Lager"},
-  {vsn, "0.2.0"},
+  {vsn, "0.2.1"},
   {modules, []},
   {applications, [
                   kernel

--- a/src/lager_loggly.app.src
+++ b/src/lager_loggly.app.src
@@ -27,7 +27,7 @@
 {application, lager_loggly,
  [
   {description, "Loggly backend for Lager"},
-  {vsn, "0.1.0"},
+  {vsn, "0.2.0"},
   {modules, []},
   {applications, [
                   kernel

--- a/src/lager_loggly_backend.erl
+++ b/src/lager_loggly_backend.erl
@@ -73,8 +73,8 @@ handle_event({log, Message}, #state{level=Level} = State) ->
     case lager_util:is_loggable(Message, Level, ?MODULE) of
         true ->
             Payload = jsx:encode(cons_metadata_to_binary_proplist(lager_msg:metadata(Message), [
-                                         {<<"level">>, convert_level(Level)}
-                                        ,{<<"message">>, any_to_binary(lager_msg:message(Message))}
+                                     {<<"level">>, any_to_binary(lager_msg:severity(Message))}
+                                    ,{<<"message">>, any_to_binary(lager_msg:message(Message))}
                                  ])),
             Request = {State#state.loggly_url, [{"te", "chunked"}], "application/json", Payload},
             RetryTimes = State#state.retry_times,
@@ -114,9 +114,6 @@ deferred_log(Request, Retries, Interval) ->
 -spec cons_metadata_to_binary_proplist(Metadata::lager_msg_metadata(), Proplist::binary_proplist()) -> Proplist::binary_proplist().
 cons_metadata_to_binary_proplist(Metadata, Proplist) ->
     lists:foldl(fun({Key, Value}, Acc) -> [{any_to_binary(Key), any_to_binary(Value)} | Acc] end, Proplist, Metadata).
-
-convert_level(Level) ->
-    any_to_binary(lager_util:num_to_level(Level)).
 
 any_to_binary(V) when is_atom(V)    -> any_to_binary(atom_to_list(V));
 any_to_binary(V) when is_pid(V)     -> any_to_binary(pid_to_list(V));

--- a/src/lager_loggly_backend.erl
+++ b/src/lager_loggly_backend.erl
@@ -44,8 +44,7 @@
 -export([deferred_log/3]).
 
 -record(state, {
-                 identity        :: string()
-                ,level          :: integer()
+                 level          :: integer()
                 ,retry_interval :: integer()
                 ,retry_times    :: integer()
                 ,loggly_url     :: string()
@@ -53,10 +52,9 @@
 
 -include_lib("lager/include/lager.hrl").
 
-init([Identity, Level, RetryTimes, RetryInterval, LogglyUrl]) ->
+init([Level, RetryTimes, RetryInterval, LogglyUrl]) ->
     State = #state{
-                    identity       = Identity
-                   ,level          = lager_util:level_to_num(Level)
+                    level          = lager_util:level_to_num(Level)
                    ,retry_interval = RetryInterval
                    ,retry_times    = RetryTimes
                    ,loggly_url     = LogglyUrl
@@ -75,11 +73,10 @@ handle_event({log, Message}, #state{level=Level} = State) ->
     case lager_util:is_loggable(Message, Level, ?MODULE) of
         true ->
             Payload = jsx:encode(cons_metadata_to_binary_proplist(lager_msg:metadata(Message), [
-                                         {<<"identity">>, any_to_binary(State#state.identity)}
-                                        ,{<<"level">>, convert_level(Level)}
+                                         {<<"level">>, convert_level(Level)}
                                         ,{<<"message">>, any_to_binary(lager_msg:message(Message))}
                                  ])),
-            Request = {State#state.loggly_url, [], "application/json", Payload},
+            Request = {State#state.loggly_url, [{"te", "chunked"}], "application/json", Payload},
             RetryTimes = State#state.retry_times,
             RetryInterval = State#state.retry_interval,
 

--- a/src/lager_loggly_backend.erl
+++ b/src/lager_loggly_backend.erl
@@ -37,11 +37,14 @@
          ,code_change/3
         ]).
 
+-type lager_msg_metadata() :: [tuple()].
+-type binary_proplist() :: [{binary(), binary()}].
+
 %%% this is only exported for the spawn call
 -export([deferred_log/3]).
 
 -record(state, {
-                identity        :: string()
+                 identity        :: string()
                 ,level          :: integer()
                 ,retry_interval :: integer()
                 ,retry_times    :: integer()
@@ -52,7 +55,7 @@
 
 init([Identity, Level, RetryTimes, RetryInterval, LogglyUrl]) ->
     State = #state{
-                   identity        = Identity
+                    identity       = Identity
                    ,level          = lager_util:level_to_num(Level)
                    ,retry_interval = RetryInterval
                    ,retry_times    = RetryTimes
@@ -68,22 +71,25 @@ handle_call(_Request, State) ->
     {ok, ok, State}.
 
 %% @private
-handle_event({log, Level, {_Date, _Time}, [_LvlStr, Loc, Message]}, State)
-        when Level =< State#state.level ->
-    Payload = jsx:to_json([
-                            {<<"identity">>, any_to_binary(State#state.identity)}
-                            ,{<<"level">>, convert_level(Level)}
-                            ,{<<"location">>, any_to_binary(Loc)}
-                            ,{<<"message">>, any_to_binary(Message)}
-                          ]),
-    Request = {State#state.loggly_url, [], "application/json", Payload},
-    RetryTimes = State#state.retry_times,
-    RetryInterval = State#state.retry_interval,
+handle_event({log, Message}, #state{level=Level} = State) ->
+    case lager_util:is_loggable(Message, Level, ?MODULE) of
+        true ->
+            Payload = jsx:encode(cons_metadata_to_binary_proplist(lager_msg:metadata(Message), [
+                                         {<<"identity">>, any_to_binary(State#state.identity)}
+                                        ,{<<"level">>, convert_level(Level)}
+                                        ,{<<"message">>, any_to_binary(lager_msg:message(Message))}
+                                 ])),
+            Request = {State#state.loggly_url, [], "application/json", Payload},
+            RetryTimes = State#state.retry_times,
+            RetryInterval = State#state.retry_interval,
 
-    %% Spawn a background process to handle sending the payload.
-    %% It will recurse until the payload has ben successfully sent.
-    spawn(?MODULE, deferred_log, [Request, RetryTimes, RetryInterval]),
-    {ok, State};
+            %% Spawn a background process to handle sending the payload.
+            %% It will recurse until the payload has ben successfully sent.
+            spawn(?MODULE, deferred_log, [Request, RetryTimes, RetryInterval]),
+            {ok, State};
+        false ->
+            {ok, State}
+    end;
 handle_event(_Event, State) ->
     {ok, State}.
 
@@ -96,9 +102,7 @@ terminate(_Reason, _State) ->
 code_change(_OldVsn, State, _Extra) ->
     {ok, State}.
 
-
 %%% Private
-
 
 deferred_log(_Request, 0, _) ->
     ok;
@@ -110,9 +114,16 @@ deferred_log(Request, Retries, Interval) ->
             deferred_log(Request, Retries - 1, Interval)
     end.
 
+-spec cons_metadata_to_binary_proplist(Metadata::lager_msg_metadata(), Proplist::binary_proplist()) -> Proplist::binary_proplist().
+cons_metadata_to_binary_proplist(Metadata, Proplist) ->
+    lists:foldl(fun({Key, Value}, Acc) -> [{any_to_binary(Key), any_to_binary(Value)} | Acc] end, Proplist, Metadata).
+
 convert_level(Level) ->
     any_to_binary(lager_util:num_to_level(Level)).
 
-any_to_binary(V) when is_atom(V)   -> any_to_binary(atom_to_list(V));
-any_to_binary(V) when is_list(V)   -> list_to_binary(V);
-any_to_binary(V) when is_binary(V) -> V.
+any_to_binary(V) when is_atom(V)    -> any_to_binary(atom_to_list(V));
+any_to_binary(V) when is_pid(V)     -> any_to_binary(pid_to_list(V));
+any_to_binary(V) when is_list(V)    -> list_to_binary(V);
+any_to_binary(V) when is_integer(V) -> integer_to_binary(V);
+any_to_binary(V) when is_binary(V)  -> V.
+


### PR DESCRIPTION
The `lager_loggly_backend` backend was updated with focus on lagers changed backend API which was updated with version `v2.0.0`. I've recently also updated and tested this changes with the latest version `v3.0.1` and didn't encountered any issues so far.

In transition to the usage of the current Loggly API, the configuration option `Identity` was removed and should now be appended directly to the `LogglyUrl` by the library user himself.
