### PR TITLE
Add missing hex related attributes and include hex.pm badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Overview
+[![Hex.pm](https://img.shields.io/hexpm/v/lager_loggly.svg?maxAge=2592000)](https://hex.pm/packages/lager_loggly) Overview
 ============
 
 This is a Loggly backend for lager which lets you send lager logs to your Loggly account.

--- a/src/lager_loggly.app.src
+++ b/src/lager_loggly.app.src
@@ -37,5 +37,8 @@
                   ,ssl
                   ,inets
                  ]},
-  {registered, []}
+  {registered, []},
+  {maintainers, ["kivra"]},
+  {licenses, ["MIT"]},
+  {links, [{"GitHub", "https://github.com/kivra/lager_loggly"}]}
  ]}.


### PR DESCRIPTION
Missing hex related attributes where included to app.src and a hex.pm badge was added to the README in preparation for a publication on hex.pm.

Notice: #3 should be merged first.
